### PR TITLE
Non-functional updates related to python and docker image versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v3
       with:
-        python-version: '3.8'
+        python-version: '3.10'
 
     - name: Run Python unit tests
       run: python3 -u -m unittest tests/tests.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2021-05-26
+## [Unreleased] - 2022-03-04
 
 ### Added
   
@@ -17,6 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### CI/CD
+
+
+## [1.3.1] - 2022-03-04
+  
+### Changed
+* Bumped python to 3.10.
+* Changed base docker image to cicirello/pyaction:4.2.0.
+* Now pulls base image from GitHub Container Registry under
+  assumption that from actions it should be faster from GitHub than
+  from Docker.
+
+### Fixed
+* Disabled pycache.
 
 
 ## [1.3.0] - 2021-05-26

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-# Copyright (c) 2020-2021 Vincent A. Cicirello
+# Copyright (c) 2020-2022 Vincent A. Cicirello
 # https://www.cicirello.org/
 # Licensed under the MIT License
-FROM cicirello/pyaction-lite:3
+FROM ghcr.io/cicirello/pyaction:4.2.0
 COPY tidyjavadocs.py /tidyjavadocs.py
 ENTRYPOINT ["/tidyjavadocs.py"]

--- a/tidyjavadocs.py
+++ b/tidyjavadocs.py
@@ -1,8 +1,8 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S python3 -B
 #
 # javadoc-cleanup: Github action for tidying up javadocs
 # 
-# Copyright (c) 2020-2021 Vincent A Cicirello
+# Copyright (c) 2020-2022 Vincent A Cicirello
 # https://www.cicirello.org/
 #
 # MIT License


### PR DESCRIPTION
## Summary
This PR includes the following changes:
* Bumped python to 3.10.
* Changed base docker image to cicirello/pyaction:4.2.0.
* Now pulls base image from GitHub Container Registry under
  assumption that from actions it should be faster from GitHub than
  from Docker.
* Disabled pycache.
