### PR TITLE
Added backwards compatibility for self-hosted runners without new GITHUB_OUTPUT env file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Dependencies
-* Bump cicirello/pyaction from 4.11.0 to 4.11.1
 
 ### CI/CD
+
+
+## [1.3.6] - 2022-10-24
+
+### Fixed
+* Some users may be using the action on a self-hosted runner not yet updated to a version supporting the
+  new GitHub Actions `GITHUB_OUTPUT` environment file. This patch adds backwards compatibility for those
+  users (e.g., it falls back to using the deprecated `set-output` if `GITHUB_OUTPUT` doesn't exist).
+
+### Dependencies
+* Bump cicirello/pyaction from 4.11.0 to 4.11.1
 
 
 ## [1.3.5] - 2022-10-20

--- a/tidyjavadocs.py
+++ b/tidyjavadocs.py
@@ -192,6 +192,9 @@ def set_outputs(names_values) :
         with open(os.environ["GITHUB_OUTPUT"], "a") as f :
             for name, value in names_values.items() :
                 print("{0}={1}".format(name, value), file=f)
+    else : # Fall-back to deprecated set-output for non-updated runners
+        for name, value in names_values.items() :
+            print("::set-output name={0}::{1}".format(name, value))
 
 if __name__ == "__main__" :
     websiteRoot = sys.argv[1]


### PR DESCRIPTION
## Summary
Some users may be using the action on a self-hosted runner not yet updated to a version supporting the new GitHub Actions `GITHUB_OUTPUT` environment file. This patch adds backwards compatibility for those users (e.g., it falls back to using the deprecated `set-output` if `GITHUB_OUTPUT` doesn't exist).

## Closing Issues
Closes #51 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
