### PR TITLE
Bump Python to 3.11 in CI/CD workflows and in Docker container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Run Python unit tests
       run: python3 -u -m unittest tests/tests.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-10-24
+## [Unreleased] - 2022-10-25
 
 ### Added
   
@@ -17,8 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Dependencies
+* Bump cicirello/pyaction from 4.11.1 to 4.12.0, including upgrading Python within the Docker container to 3.11.
 
 ### CI/CD
+* Bump Python to 3.11 in CI/CD workflows.
 
 
 ## [1.3.6] - 2022-10-24

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2020-2022 Vincent A. Cicirello
 # https://www.cicirello.org/
 # Licensed under the MIT License
-FROM ghcr.io/cicirello/pyaction:4.11.1
+FROM ghcr.io/cicirello/pyaction:4.12.0
 COPY tidyjavadocs.py /tidyjavadocs.py
 ENTRYPOINT ["/tidyjavadocs.py"]


### PR DESCRIPTION
## Summary
* Bump cicirello/pyaction from 4.11.1 to 4.12.0, including upgrading Python within the Docker container to 3.11.
* Bump Python to 3.11 in CI/CD workflows.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
